### PR TITLE
Make checkstyle fail the build on warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
               <encoding>UTF-8</encoding>
               <consoleOutput>true</consoleOutput>
               <failsOnError>true</failsOnError>
+              <violationSeverity>warning</violationSeverity>
               <linkXRef>false</linkXRef>
             </configuration>
             <goals>


### PR DESCRIPTION
To make the applied coding standards more obvious the build should fail if checkstyle produces a warning.