### PR TITLE
TG-3132: Tax should be added to all types of items, not just Apparel …

### DIFF
--- a/src/main/java/com/diffblue/demo/ecommerce/models/Cart.java
+++ b/src/main/java/com/diffblue/demo/ecommerce/models/Cart.java
@@ -102,7 +102,7 @@ public class Cart {
    */
   public double checkTax(Product product, double productTotal) {
     Category cateory = product.getCategory();
-    if (!"Child".equals(product.getSize()) && "Apparel".equals(cateory.getName()) ) {
+    if (!("Child".equals(product.getSize()) && "Apparel".equals(cateory.getName()))) {
       this.tax = this.tax + (productTotal * taxRate);
     }
     return tax;


### PR DESCRIPTION
When running ecommerce-demo, tax was only being added to products of category "Apparel" with size "Adult". The logic unintentionally excluded all other product categories.
This change ensures tax is added to all products except Apparel of size "Child".